### PR TITLE
Remove unecessary parameter from catch clause

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - 'node'
   - '10'
-  - '9'
 os:
   - windows
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - 'node'
+  - '11'
   - '10'
 os:
   - windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - 'node'
   - '10'
-  - '8'
+  - '9'
 os:
   - windows
   - linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Changed
 
-- Drop support for Node.js versions older than version 9
+- Drop support for Node.js versions older than version 10
 
 ## [2.0.0] - 2018-10-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2019-04-30
+
+### Changed
+
+- Drop support for Node.js versions older than version 9
+
 ## [2.0.0] - 2018-10-28
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nice-try",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "authors": [
     "Tobias Reich <tobias@electerious.com>"
   ],

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,6 @@
  */
 module.exports = function(fn) {
 
-	try { return fn() } catch (e) {}
+	try { return fn() } catch {}
 
 }


### PR DESCRIPTION
Since Node 9 you don't need to declare the error on a catch clause unless you intend to use it